### PR TITLE
Restructure `HandleTable` <-> `EmState` relation

### DIFF
--- a/vm-ecosystem/vmos/Cargo.toml
+++ b/vm-ecosystem/vmos/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 sdl2 = "0.37.0"
+snowflake = "1.3.0"

--- a/vm-ecosystem/vmos/src/emul_state.rs
+++ b/vm-ecosystem/vmos/src/emul_state.rs
@@ -1,7 +1,8 @@
-use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
 
 use sdl2::event::Event;
 use sdl2::libc;
+use snowflake::ProcessUniqueId;
 
 use crate::cpu::{Cpu, TrapCause};
 
@@ -26,10 +27,202 @@ impl SigBit {
 }
 
 /// Handle table entries, which refer to kernel-side resources, are of this type.
-pub type HandleTableEntry = Option<Arc<Mutex<dyn Manageable>>>;
+pub type HandleTableEntry = Option<Box<dyn Manageable>>;
 
 /// Handle table is a vector of Handle Table Entries.
 pub type HandleTable = Vec<HandleTableEntry>;
+
+/// Stores `HandleTable`s for each `EmState` in the current process.
+#[derive(Default)]
+pub struct HandleTableRepo {
+    /// Each `EmState` has a unique id (within the current process), which can be used
+    /// to get at the `EmState`'s `HandleTable`
+    /// This table provides a way of making emulator-managed resources
+    /// available to the running virtual processor environment.
+    em_state_handle_table_map: HashMap<EmStateUniqueProcessId, HandleTable>,
+}
+
+impl HandleTableRepo {
+    /// Create a new `HandleTableRepo`
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Insert a new `HandleTable` with the provided `prepopulated_entry` and associate it
+    /// with the given `EmStateUniqueProcessId` (which originates from an `EmState`).
+    ///
+    /// If the repo did not have this `EmStateUniqueProcessId` present, `None` is returned.
+    /// If the repo did have this `EmStateUniqueProcessId` present, the `HandleTable` is updated,
+    /// and the old `HandleTable` is returned.
+    pub fn insert_new_handle_table(
+        &mut self,
+        id: EmStateUniqueProcessId,
+        prepopulated_entry: Box<dyn Manageable>,
+    ) -> Option<HandleTable> {
+        // Create initial handle table.  We pre-populate handle 4 with a handle to
+        // the currently running program.
+        let mut v: Vec<_> = (0..64).map(|_| None).collect();
+        v[4] = Some(prepopulated_entry);
+        self.em_state_handle_table_map.insert(id, v)
+    }
+
+    pub fn call_handler(&mut self, em: &mut EmState, proc: u64) {
+        em.cpu.pc = proc;
+
+        loop {
+            em.cpu.run_until_trap(&mut em.mem);
+
+            match em.cpu.scause {
+                TrapCause::EnvironmentCallFromUmode => {
+                    let function_code = em.cpu.xr[17];
+
+                    match function_code {
+                        // Return from event handler
+                        0x0000 => return,
+
+                        // Get Attributes on a handle
+                        0x0001 => {
+                            em.cpu.pc = em.cpu.sepc + 4;
+                            em.cpu.scause = TrapCause::None;
+
+                            let which = em.cpu.xr[10] as usize;
+
+                            let resource = self
+                                .em_state_handle_table_map
+                                .get_mut(&em.unique_process_id)
+                                .and_then(|handle_table| handle_table.get_mut(which));
+                            if let Some(Some(r)) = resource {
+                                r.get_attributes(em);
+                            }
+                        }
+
+                        // Set Attributes on a handle
+                        0x0002 => {
+                            em.cpu.pc = em.cpu.sepc + 4;
+                            em.cpu.scause = TrapCause::None;
+
+                            let which = em.cpu.xr[10] as usize;
+
+                            let resource = self
+                                .em_state_handle_table_map
+                                .get_mut(&em.unique_process_id)
+                                .and_then(|handle_table| handle_table.get_mut(which));
+                            if let Some(Some(r)) = resource {
+                                r.set_attributes(em);
+                            }
+                        }
+
+                        // Close a handle
+                        0x0003 => {
+                            em.cpu.pc = em.cpu.sepc + 4;
+                            em.cpu.scause = TrapCause::None;
+
+                            let which = em.cpu.xr[10] as usize;
+
+                            let mut resource = self
+                                .em_state_handle_table_map
+                                .get_mut(&em.unique_process_id)
+                                .and_then(|handle_table| {
+                                    handle_table.get_mut(which).map(Option::take)
+                                });
+                            if let Some(Some(r)) = resource.as_mut() {
+                                r.close(em);
+                            }
+                        }
+
+                        0x002A => {
+                            print!("{}", em.cpu.xr[10] as u8 as char);
+
+                            em.cpu.scause = TrapCause::None;
+                            em.cpu.pc = em.cpu.sepc + 4;
+                        }
+
+                        // Create a timer.
+                        //
+                        // On Entry:
+                        // A0 = Signal bit to trigger when timer expires.
+                        // A1 = Period (note: only low 32 bits are recognized in SDL-backed versions of
+                        // VM/OS).
+                        // A2 = Non-zero if the timer is enabled; zero if the timer is disabled.
+                        //
+                        // On Exit:
+                        // A0 = non-zero if successful; zero otherwise.
+                        // A1 = If successful, the handle of the created timer instance.  Otherwise, a
+                        // reason code for the failure.
+                        //
+                        // If the timer could not be created, then A1 holds the reason code:
+                        //
+                        // - 0 -- No more handles available.
+                        // - 1 -- Signal bit out of range.
+                        0x0100 => {
+                            match SigBit::new(em.cpu.xr[10]) {
+                                Some(sb) => {
+                                    let signal = sb;
+                                    let period = em.cpu.xr[11] as u32;
+                                    let enabled = if em.cpu.xr[12] != 0 { true } else { false };
+
+                                    match self.find_free_handle(em.unique_process_id) {
+                                        Some((which, handle_table)) => {
+                                            handle_table[which] = Some(
+                                                TimerTicker::new(
+                                                    signal,
+                                                    period,
+                                                    enabled,
+                                                    &mut em.timer_subsystem,
+                                                    &mut em.event_subsystem,
+                                                    em.timer_tick,
+                                                )
+                                                .as_manageable(),
+                                            );
+                                            em.cpu.xr[10] = 1;
+                                            em.cpu.xr[11] = which as u64;
+                                        }
+
+                                        None => {
+                                            em.cpu.xr[10] = 0;
+                                            em.cpu.xr[11] = 0;
+                                        }
+                                    };
+                                }
+
+                                None => {
+                                    em.cpu.xr[10] = 0;
+                                    em.cpu.xr[11] = 1;
+                                }
+                            }
+
+                            em.cpu.scause = TrapCause::None;
+                            em.cpu.pc = em.cpu.sepc + 4;
+                        }
+
+                        _ => break,
+                    }
+                }
+
+                _ => break,
+            }
+        }
+    }
+
+    /// Answer with the next free handle index together with the actual handle table, or else `None`.
+    /// Note: Under the assumption that no entry of the `HandleTable` is removed after this method returns,
+    /// indexing into it with the simultaneously returned index is always valid and will never panic.
+    fn find_free_handle(
+        &mut self,
+        em_unique_proc_id: EmStateUniqueProcessId,
+    ) -> Option<(usize, &mut HandleTable)> {
+        if let Some(handle_table) = self.em_state_handle_table_map.get_mut(&em_unique_proc_id) {
+            let free_idx = handle_table
+                .into_iter()
+                .enumerate()
+                // find the first free entry and return it's index
+                .find_map(|(i, m)| m.is_none().then_some(i));
+            free_idx.zip(Some(handle_table))
+        } else {
+            None
+        }
+    }
+}
 
 /// All resources are required to be "manageable."  In this way, all resources can be closed,
 /// can have attributes discovered, and can have attributes altered if required.
@@ -111,16 +304,18 @@ pub trait Manageable {
     }
 }
 
+pub type EmStateUniqueProcessId = ProcessUniqueId;
+
 /// "Supervisor" state.  This includes things which a typical OS kernel might like to keep track
 /// of.
 pub struct EmState {
+    /// An id that is unique for the whole process and is used
+    /// to identiy an `EmState` instance
+    pub unique_process_id: EmStateUniqueProcessId,
     /// The (virtual) process' memory space.
     pub mem: Vec<u8>,
     /// The (virtual) process' registers and such.
     pub cpu: Cpu,
-    /// The process' handle table.  This table provides a way of making emulator-managed resources
-    /// available to the running virtual processor environment.
-    pub handle_table: HandleTable,
     /// POSIX Return Code.  This will be copied from a ProgramInstance structure when that instance
     /// is closed.
     pub return_code: i64,
@@ -134,144 +329,6 @@ pub struct EmState {
     pub timer_tick: u32,
 }
 
-impl EmState {
-    /// Answer with the next free handle, or else None.
-    fn find_free_handle(&self) -> Option<usize> {
-        let mut i = 0;
-        while i < self.handle_table.len() {
-            if self.handle_table[i].is_none() {
-                return Some(i);
-            }
-
-            i = i + 1;
-        }
-        None
-    }
-}
-
-pub fn call_handler(em: &mut EmState, proc: u64) {
-    em.cpu.pc = proc;
-
-    loop {
-        em.cpu.run_until_trap(&mut em.mem);
-
-        match em.cpu.scause {
-            TrapCause::EnvironmentCallFromUmode => {
-                let function_code = em.cpu.xr[17];
-
-                match function_code {
-                    // Return from event handler
-                    0x0000 => return,
-
-                    // Get Attributes on a handle
-                    0x0001 => {
-                        em.cpu.pc = em.cpu.sepc + 4;
-                        em.cpu.scause = TrapCause::None;
-
-                        let which = em.cpu.xr[10] as usize;
-
-                        let resource = &mut em.handle_table[which];
-                        if let Some(rc_refcell_obj) = resource {
-                            let mut the_obj = rc_refcell_obj.lock().unwrap();
-                            the_obj.get_attributes(em);
-                        }
-                    }
-
-                    // Set Attributes on a handle
-                    0x0002 => {
-                        em.cpu.pc = em.cpu.sepc + 4;
-                        em.cpu.scause = TrapCause::None;
-
-                        let which = em.cpu.xr[10] as usize;
-
-                        let resource = &mut em.handle_table[which];
-                        if let Some(rc_refcell_obj) = resource {
-                            let mut the_obj = rc_refcell_obj.lock().unwrap();
-                            the_obj.set_attributes(em);
-                        }
-                    }
-
-                    // Close a handle
-                    0x0003 => {
-                        em.cpu.pc = em.cpu.sepc + 4;
-                        em.cpu.scause = TrapCause::None;
-
-                        let which = em.cpu.xr[10] as usize;
-
-                        let resource = &mut em.handle_table[which];
-                        if let Some(rc_refcell_obj) = resource {
-                            let mut the_obj = rc_refcell_obj.lock().unwrap();
-                            the_obj.close(em);
-                        }
-
-                        em.handle_table[which] = None;
-                    }
-
-                    0x002A => {
-                        print!("{}", em.cpu.xr[10] as u8 as char);
-
-                        em.cpu.scause = TrapCause::None;
-                        em.cpu.pc = em.cpu.sepc + 4;
-                    }
-
-                    // Create a timer.
-                    //
-                    // On Entry:
-                    // A0 = Signal bit to trigger when timer expires.
-                    // A1 = Period (note: only low 32 bits are recognized in SDL-backed versions of
-                    // VM/OS).
-                    // A2 = Non-zero if the timer is enabled; zero if the timer is disabled.
-                    //
-                    // On Exit:
-                    // A0 = non-zero if successful; zero otherwise.
-                    // A1 = If successful, the handle of the created timer instance.  Otherwise, a
-                    // reason code for the failure.
-                    //
-                    // If the timer could not be created, then A1 holds the reason code:
-                    //
-                    // - 0 -- No more handles available.
-                    // - 1 -- Signal bit out of range.
-
-                    0x0100 => {
-                        match SigBit::new(em.cpu.xr[10]) {
-                            Some(sb) => {
-                                let signal = sb;
-                                let period = em.cpu.xr[11] as u32;
-                                let enabled = if em.cpu.xr[12] != 0 { true } else { false };
-
-                                match em.find_free_handle() {
-                                    Some(which) => {
-                                        em.handle_table[which] = Some(TimerTicker::new(signal, period, enabled, &mut em.timer_subsystem, &mut em.event_subsystem, em.timer_tick).as_manageable());
-                                        em.cpu.xr[10] = 1;
-                                        em.cpu.xr[11] = which as u64;
-                                    }
-
-                                    None => {
-                                        em.cpu.xr[10] = 0;
-                                        em.cpu.xr[11] = 0;
-                                    }
-                                };
-                            }
-
-                            None => {
-                                em.cpu.xr[10] = 0;
-                                em.cpu.xr[11] = 1;
-                            }
-                        }
-
-                        em.cpu.scause = TrapCause::None;
-                        em.cpu.pc = em.cpu.sepc + 4;
-                    }
-
-                    _ => break,
-                }
-            }
-
-            _ => break,
-        }
-    }
-}
-
 struct TimerTicker<'a> {
     signal: SigBit,
     period: u32,
@@ -279,33 +336,37 @@ struct TimerTicker<'a> {
     ticker: Option<Box<sdl2::timer::Timer<'a, 'a>>>,
 }
 
-impl<'a> Manageable for TimerTicker<'a> {
-}
+impl<'a> Manageable for TimerTicker<'a> {}
 
 impl<'a> TimerTicker<'a> {
-    pub fn new(signal: SigBit, period: u32, enabled: bool, timer_subsystem: &mut sdl2::TimerSubsystem, event_subsystem: &mut sdl2::EventSubsystem, timer_tick: u32) -> Self {
-        let mut ticker: Option<sdl2::timer::Timer> = None;
+    pub fn new(
+        signal: SigBit,
+        period: u32,
+        enabled: bool,
+        timer_subsystem: &mut sdl2::TimerSubsystem,
+        event_subsystem: &mut sdl2::EventSubsystem,
+        timer_tick: u32,
+    ) -> Self {
+        let mut ticker = None;
 
         if enabled {
-            ticker = Some(Box::new(
-                timer_subsystem.add_timer(
-                    period,
-                    Box::new(move || {
-                        let _ = event_subsystem
-                            .push_event(Event::User {
-                                timestamp: 0,
-                                window_id: 0,
-                                type_: timer_tick,
-                                code: signal.bit() as i32,
-                                data1: 0 as *mut libc::c_void,
-                                data2: 0 as *mut libc::c_void,
-                            })
-                            .unwrap();
+            ticker = Some(Box::new(timer_subsystem.add_timer(
+                period,
+                Box::new(move || {
+                    let _ = event_subsystem
+                        .push_event(Event::User {
+                            timestamp: 0,
+                            window_id: 0,
+                            type_: timer_tick,
+                            code: signal.bit() as i32,
+                            data1: 0 as *mut libc::c_void,
+                            data2: 0 as *mut libc::c_void,
+                        })
+                        .unwrap();
 
-                        period
-                    })
-                )
-            ));
+                    period
+                }),
+            )));
         }
 
         Self {
@@ -316,9 +377,7 @@ impl<'a> TimerTicker<'a> {
         }
     }
 
-    pub fn as_manageable(self) -> Arc<Mutex<dyn Manageable>> {
-        Arc::new(Mutex::new(self))
+    pub fn as_manageable(self) -> Box<dyn Manageable + 'a> {
+        Box::new(self)
     }
 }
-
-

--- a/vm-ecosystem/vmos/src/program_instance.rs
+++ b/vm-ecosystem/vmos/src/program_instance.rs
@@ -1,8 +1,6 @@
 //! Minimal, yet still useful, example of a resource that can be accessed via the
 //! handle table of a running VM/OS application.
 
-use std::sync::{Arc, Mutex};
-
 use crate::{EmState, Manageable};
 
 /// This "resource" lets a program set the return code before quitting the program.
@@ -16,8 +14,8 @@ impl ProgramInstance {
         Self { return_code: 0 }
     }
 
-    pub fn as_manageable(self) -> Arc<Mutex<dyn Manageable>> {
-        Arc::new(Mutex::new(self))
+    pub fn as_manageable(self) -> Box<dyn Manageable> {
+        Box::new(self)
     }
 }
 


### PR DESCRIPTION
WARNING: This code still doesn't compile - see further details below in the last paragraph.

Previously, `HandleTable` and `EmState` had a circular dependency on each other, which has caused borrowing issues.

The new relationship is as follows:
- each `EmState` has a unique process id
- this process id is associated with it's own `HandleTable`
- all of these associations are stored in a new `HandleTableRepo`
```
                HandleTableRepo

EmStateUniqueProcessId  ->  HandleTable,
EmStateUniqueProcessId  ->  HandleTable,
EmStateUniqueProcessId  ->  HandleTable,
            ...         ...     ...
```
Using the unique process id (which implements `Copy`) as a key to a `HandleTable` has the advantage that we don't need to store the whole `EmState` for the association, which prevents borrowing issues.

Note: For generating the above mentioned process ids, we rely on the (well established) `snowflake` crate:
https://crates.io/crates/snowflake

WARNING: There is still one piece of code which doesn't compile, which has to do with crossing the FFI boundary to `sdl2`: When trying to add a timer to `TimerSubsystem`, it's closure is required to be `Send`, but our passed in closure doesn't fulfill this requirement, because it must use `*mut ()` pointers due to another `sdl2`-API and `*mut ()` pointers are not `Send`:
```rust
timer_subsystem.add_timer(
    period,
    Box::new(move || {
        //   ^^^ this closure needs to be `Send`
        let _ = event_subsystem
            .push_event(Event::User {
                timestamp: 0,
                window_id: 0,
                type_: timer_tick,
                code: signal.bit() as i32,
                data1: 0 as *mut libc::c_void,
                        //  ^^^^^^^^^^^^^^^^^^ this is not `Send`
                data2: 0 as *mut libc::c_void,
                        //  ^^^^^^^^^^^^^^^^^^ this is not `Send`
            })
            .unwrap();

        period
    }),
)
```
This seems to be a __fundamental__ incompatibility between the APIs of `sdl2`. To resolve this, a new API __within `sdl2`__ needs to be provided that turns the following API...
```rust
enum Event {
    // ...
    // some other omitted variants
    // ...
    User {
        timestamp: u32,
        window_id: u32,
        type_: u32,
        code: i32,
        data1: *mut c_void,
        data2: *mut c_void,
    },
}
```
...into roughly this new API...:
```rust
enum Event {
    // ...
    // some other omitted variants
    // ...
    User {
        timestamp: u32,
        window_id: u32,
        type_: u32,
        code: i32,
        data: Data
    },
}
```
...where `Data` is a wrapper struct that is provided by `sdl2` and implements `Send`.